### PR TITLE
ENH: Upgrade GitHub actions to `checkout@v3` and `upload-artifact@v3`

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Build Docker Image for Doxygen
@@ -25,7 +25,7 @@ jobs:
           docker cp itk-dox:/ITKDoxygen.tar.gz artifacts/ITKDoxygen-${GITHUB_SHA}.tar.gz
           docker cp itk-dox:/ITKDoxygenXML.tar.gz artifacts/ITKDoxygenXML-${GITHUB_SHA}.tar.gz
       - name: Archive Doxygen Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doxygen
           path: |


### PR DESCRIPTION
Fix `doxygen` workflow action warnings linked to `Node.js`: bump `actions/checkout` to `v3` and `actions/upload-artifact` to `v3`.

Fixes:
```
doxygen
The following actions uses node12 which is deprecated and will be forced to run on node16:
actions/checkout@v2, actions/upload-artifact@v2.
For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKDoxygen/actions/runs/5720889621