### PR TITLE
Address /usr/sbin/dot error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
   python3 \
   && apt-get clean
 
+RUN ln /usr/bin/dot /usr/sbin/dot
+
 RUN git clone https://github.com/doxygen/doxygen.git && \
     ( cd doxygen && \
       git checkout Release_1_9_3 && \


### PR DESCRIPTION
This is a work around to address doxygen errors related to command /usr/sbin/dot not being found. The CMake based doxygen based configuration file correct set DOT_PATH to /usr/bin. It is unclear why sbin in being used.