### PR TITLE
DOC: Improve README instructions & fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,31 +17,70 @@ Overview
 
 This dockerfile has been created to facilitate the creation of
 [ITK](https://github.com/InsightSoftwareConsortium/ITK)
-[Doxygen](https://doxygen.nl/) documentation in a reproducible way.
+[Doxygen](https://doxygen.nl/)
+documentation in a reproducible way.
 
-The documentation is built nightly on the current/latest ITK commit, and
-deployed to GitHub pages at:
-https://insightsoftwareconsortium.github.io/ITKDoxygen/
+The documentation is built nightly on the current/latest ITK commit, 
+and deployed to GitHub pages at: https://insightsoftwareconsortium.github.io/ITKDoxygen/
 
-To create the the documentation locally, run the following commands:
+To create the documentation locally, run the following commands:
 
+### 1. Clone the ITKDoxygen Repository
+
+### 2. Build the Docker Image
 ```shell
-docker build --build-arg TAG=v1.1.0 . -f Dockerfile -t itk-doxygen
-docker build -f Dockerfile -t itk-doxygen .
+docker build . -f Dockerfile -t itk-doxygen
+```
 
-export TAG=v1.2.0
+### 3. Export TAG Environment Variable
+The `TAG` environment variable is used to specify a filename for the tarballs 
+to be copied from the Docker container to your local working directory (see 
+[step 5](#5-copy-the-doxygen-documentation)).
+Useful for naming multiple versions of the documentation.
+
+Here we have set it to *alpha*, but you may change it as needed.
+```shell
+export TAG=alpha
+```
+
+### 4. Run the Docker Container
+#### Option 1: Using the Latest ITK Repository
+```shell
 docker run --env TAG --name itk-dox itk-doxygen
 ```
 
-or
-
+#### Option 2: Using a Local ITK Repository
+If you want to build documentation from a local ITK repository, 
+remove the `readonly` parameter from the mount command and 
+specify an absolute path to the aforementioned repository.
 ```shell
 docker run \
   --env TAG \
-  --mount type=bind,source=!ITK,destination=/work/ITK,readonly \
+  --mount type=bind,source=/path/to/your/clone,destination=/work/ITK,readonly \
   --name itk-dox itk-doxygen
+```
+> **Note:** Both these commands may take a while to complete
 
+### 5. Copy the Doxygen Documentation
+
+The following commands will copy the tarballs from the
+Docker container to your local working directory.
+```shell
 docker cp itk-dox:/ITKDoxygen.tar.gz SimpleITKDoxygen${TAG:+-${TAG}}.tar.gz
 docker cp itk-dox:/ITKDoxygenXML.tar.gz SimpleITKDoxygenXML${TAG:+-${TAG}}.tar.gz
+
+# Remove the Docker container after copying the tarballs
 docker rm itk-dox
 ```
+
+### 6. Extract the Doxygen Documentation
+Untar these tarballs to extract and verify the Doxygen documentation. 
+The `SimpleITKDoxygen` tarball contains the HTML documentation,
+while the `SimpleITKDoxygenXML` tarball contains the XML documentation.
+
+```shell
+tar -xzf SimpleITKDoxygen${TAG:+-${TAG}}.tar.gz
+tar -xzf SimpleITKDoxygenXML${TAG:+-${TAG}}.tar.gz
+```
+
+You may now view the Doxygen documentation by opening the `html/index.html` file.


### PR DESCRIPTION
PR #3 transitioned the instructions into Markdown syntax, but some issues arose from this. 


1. [These build lines](https://github.com/InsightSoftwareConsortium/ITKDoxygen/pull/3/commits/fa2ca68cffb8fe55474d4eeb362b1ebf81c7e610#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R27) are synonymous and should be merged into one

If we look at PR #3, the first line was commented out before, but during the PR it was uncommented leading to this redundancy. The only difference was the build argument passing in the `TAG` variable, but if we examine the [Dockerfile](https://github.com/InsightSoftwareConsortium/ITKDoxygen/blob/master/Dockerfile) there is no mention of this. Thus, the `TAG` variable seems to be unnecessary. 

2. Incorrect grouping of commands before/after the `or`

The location of the `or` and the way the commands were grouped were incorrect. Instead of everything being clumped together, the `or` should have separated the two ways to run the Docker container. Additionally, for those who wish to build a modified version of the documentation to test changes, I removed the [`readonly`](https://github.com/InsightSoftwareConsortium/ITKDoxygen/blob/master/README.md?plain=1#L41) part of the command.

3. Added separation of commands and numbered steps in order to improve readability

Hope this helps! Feedback is appreciated :)
@viv511
