### PR TITLE
ENH: Fix Docker and Doxygen workflow actions `Node.js` warnings

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build Docker Image for Doxygen
@@ -25,7 +25,7 @@ jobs:
           docker cp itk-dox:/ITKDoxygen.tar.gz artifacts/ITKDoxygen-${GITHUB_SHA}.tar.gz
           docker cp itk-dox:/ITKDoxygenXML.tar.gz artifacts/ITKDoxygenXML-${GITHUB_SHA}.tar.gz
       - name: Archive Doxygen Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: doxygen
           path: |

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag itk-doxygen-docker:$(date +%Y-%m-%d-%H-%M)


### PR DESCRIPTION
Fix Docker image build and Doxygen workflow actions warnings linked to `Node.js`: bump `actions/checkout` and `actions/upload-artifact` to v4.

Fixes:
```
build
The following actions use a deprecated Node.js version and will be forced to run on node20:
 actions/checkout@v3.
 For more info:
 https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

```
doxygen
The following actions use a deprecated Node.js version and will be forced to run on node20:
 actions/checkout@v3, actions/upload-artifact@v3.
 For more info:
 https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

and
```
Deprecation notice: v1, v2, and v3 of the artifact actions
The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "doxygen".
Please update your workflow to use v4 of the artifact actions.
Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKDoxygen/actions/runs/10436038564 and
https://github.com/InsightSoftwareConsortium/ITKDoxygen/actions/runs/10542471843