### PR TITLE
BUG: Set ITK default GIT_TAG to master

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -6,7 +6,7 @@ SRC_DIR="/work/ITK"
 BLD_DIR="/work/ITK-bld"
 
 # If the SRC_DIR is not mounted, then this tag will be checked out
-GIT_TAG=${GIT_TAG:-"main"}
+GIT_TAG=${GIT_TAG:-"master"}
 
 set -xe
 


### PR DESCRIPTION
Fix from fb6c5ce0d87b78828408fab12a53624dc2b012bb.
