### PR TITLE
ENH: Install perl and bibtex inside the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && \
   ninja-build \
   graphviz \
   python3 \
+  perl \
+  pybtex \
   && apt-get clean
 
 RUN ln /usr/bin/dot /usr/sbin/dot


### PR DESCRIPTION
This is needed for turning bibtex references into hyperlinks in the generated documentation. Closes #26.