### PR TITLE
ENH: Trigger RTD builds with nightly GHA builds

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -58,6 +58,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.github_token }}
 
+      - name: Trigger ReadTheDocs build
+        if: github.ref == 'refs/heads/main'
+        run: |
+          curl -X POST \
+            -d "token=${{ secrets.rtd_webhook_secret }}" \
+            -H "Content-Type: application/json" \
+            "https://readthedocs.org/api/v2/webhook/itkdoxygen/290126/"
+
       - name: Prepare HTML for GitHub Pages
         if: github.ref == 'refs/heads/main'
         run: |


### PR DESCRIPTION
On main, after the GitHub Action cronjob nightly builds and pushes to
the `latest` GitHub Release, we trigger a RTD build to update the
published documentation.
