### PR TITLE
BUG: Add the branches parameter to RTD trigger

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           curl -X POST \
             -H "Content-Type: application/json" \
-            -d '{"token": "${{ secrets.rtd_webhook_secret }}"}' \
+            -d '{"token": "${{ secrets.rtd_webhook_secret }}", "branches": "latest"}' \
             "https://readthedocs.org/api/v2/webhook/itkdoxygen/290126/"
 
       - name: Prepare HTML for GitHub Pages


### PR DESCRIPTION
Unlike what their documentation suggests:

  https://docsdhuha.readthedocs.io/en/latest/webhooks.html

this is required for a successful trigger.
