### PR TITLE
Address "FromAsCasing" waring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 as itk-doxygen
+FROM ubuntu:24.04 AS itk-doxygen
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Fixed the following:
```
warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```