### PR TITLE
ENH: Publish the Doxygen tag file; document VtkGlue and OpenCV classes

### DIFF
--- a/.github/workflows/Doxygen.yml
+++ b/.github/workflows/Doxygen.yml
@@ -25,6 +25,7 @@ jobs:
           mkdir -p artifacts
           docker cp itk-dox:/ITKDoxygen.tar.gz artifacts/ITKDoxygen-${GITHUB_SHA}.tar.gz
           docker cp itk-dox:/ITKDoxygenXML.tar.gz artifacts/ITKDoxygenXML-${GITHUB_SHA}.tar.gz
+          docker cp itk-dox:/ITKDoxygenDocTag.gz artifacts/ITKDoxygenDocTag-${GITHUB_SHA}.gz
 
       - name: Archive Doxygen Artifacts
         uses: actions/upload-artifact@v7
@@ -32,6 +33,7 @@ jobs:
           name: doxygen
           path: |
             artifacts/ITKDoxygenXML-*.tar.gz
+            artifacts/ITKDoxygenDocTag-*.gz
             artifacts/ITKDoxygen-*.tar.gz
 
       - name: Publish to latest GitHub Release
@@ -50,6 +52,8 @@ jobs:
           gunzip InsightDoxygenDocXml-latest.tar.gz
           zstd -f -10 -T6 --long=31 InsightDoxygenDocXml-latest.tar -o InsightDoxygenDocXml-latest.tar.zst
           gzip -9 InsightDoxygenDocXml-latest.tar
+
+          cp ITKDoxygenDocTag-*.gz InsightDoxygenDocTag-latest.gz
 
           popd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && \
   git \
   ninja-build \
   graphviz \
+  libvtk9-dev \
+  libopencv-dev \
   python3 \
   perl \
   texlive-bibtex-extra \

--- a/run.sh
+++ b/run.sh
@@ -32,8 +32,12 @@ mkdir -p ${BLD_DIR} && \
           -DModule_MGHIO:BOOL=ON \
           -DModule_GenericLabelInterpolator:BOOL=ON \
           -DModule_AdaptiveDenoising:BOOL=ON \
+          -DModule_ITKVtkGlue:BOOL=ON \
+          -DModule_ITKVideoBridgeOpenCV:BOOL=ON \
           ${SRC_DIR} && \
     cmake --build . --target Documentation && \
     cd ${BLD_DIR}/Utilities/Doxygen && \
     tar --exclude=\*.md5 --exclude=\*.map -zcvf /ITKDoxygen.tar.gz ./html && \
     tar -zcvf /ITKDoxygenXML.tar.gz ./xml
+
+gzip -9 -c ${BLD_DIR}/Utilities/Doxygen/InsightDoxygen.tag > /ITKDoxygenDocTag.gz


### PR DESCRIPTION
Publishes the Doxygen tag file alongside the Html/Xml artifacts (it is generated by every run but was never packaged — the `InsightDoxygenDocTag` asset last shipped with ITK v5.3.0), and enables the VtkGlue and OpenCV bridge modules so their classes return to the XML/tag.

<details>
<summary>Details</summary>

- `run.sh`: gzip `InsightDoxygen.tag` (generated next to `html/` and `xml/`) to `/ITKDoxygenDocTag.gz`; enable `Module_ITKVtkGlue` and `Module_ITKVideoBridgeOpenCV` (both in-tree in ITK main; their classes — `ImageToVTKImageFilter`, `VTKImageToImageFilter`, `OpenCVImageBridge` — were documented in the 5.3-era artifacts but are absent from current ones, breaking ITKSphinxExamples breathelinks).
- `Dockerfile`: add `libvtk9-dev` and `libopencv-dev` so the modules configure.
- `Doxygen.yml`: copy/upload the new tag artifact and include `InsightDoxygenDocTag-latest.gz` in the `latest` release.

ITK's `Release.md` still lists the DocTag among required release artifacts; with this change the "download from latest ITKDoxygen release and rename" flow picks it up again. Companion ITK PR publishes a per-release tag from the warnings-only CI as well.

</details>

<!--
provenance: claude-code session 2026-06-12
consumers: ITKSphinxExamples DownloadDoxygenTAG.cmake (pinned to v5.3.0 for lack of newer), #458
-->
