### PR TITLE
COMP: Install Qt5 development packages required by VTK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && \
   ninja-build \
   graphviz \
   libvtk9-dev \
+  qtbase5-dev \
+  libqt5opengl5-dev \
   libopencv-dev \
   python3 \
   perl \


### PR DESCRIPTION
Fixes the nightly doxygen run broken by #43: Ubuntu's `libvtk9-dev` is built with Qt support, so `find_package(VTK)` during the VtkGlue-enabled ITK configure fails without Qt5 development files (`Could not find ... Qt5Config.cmake`, run 27425516546). Adds `qtbase5-dev` and `libqt5opengl5-dev` to the image.

<!--
provenance: claude-code session 2026-06-12; regression introduced by #43, caught on the first post-merge run
verification: PR docker-image build validates package resolution; the post-merge main run is the end-to-end proof (local docker daemon unavailable)
-->
